### PR TITLE
fix(runtime): accept custom outcome values for multi-way conditional routing

### DIFF
--- a/internal/attractor/cond/cond_test.go
+++ b/internal/attractor/cond/cond_test.go
@@ -36,3 +36,28 @@ func TestEvaluate(t *testing.T) {
 		}
 	}
 }
+
+func TestEvaluate_CustomOutcome(t *testing.T) {
+	// Custom outcome values used in reference dotfiles (semport.dot: outcome=process, outcome=done).
+	ctx := runtime.NewContext()
+	out := runtime.Outcome{Status: runtime.StageStatus("process")}
+
+	cases := []struct {
+		cond string
+		want bool
+	}{
+		{"outcome=process", true},
+		{"outcome=done", false},
+		{"outcome!=process", false},
+		{"outcome!=done", true},
+	}
+	for _, tc := range cases {
+		got, err := Evaluate(tc.cond, out, ctx)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error: %v", tc.cond, err)
+		}
+		if got != tc.want {
+			t.Fatalf("Evaluate(%q)=%v, want %v", tc.cond, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `ParseStageStatus` now accepts custom outcome values (e.g. `process`, `done`, `port`, `skip`) instead of rejecting them as invalid
- This fixes silent routing failures in any pipeline using custom outcomes for multi-way conditional edges
- Added `IsCanonical()` helper to distinguish canonical statuses from custom routing values

Fixes the spec/implementation drift where reference dotfiles (`semport.dot`, `consensus_task.dot`) and the `english-to-dotfile` skill document custom outcomes as a working feature, but the engine silently discards them.

## Root cause

`ParseStageStatus()` only accepted 5 canonical values (`success`, `partial_success`, `retry`, `fail`, `skipped`). When an LLM wrote `status.json` with `{"status": "process"}`:

1. `DecodeOutcomeJSON` called `Canonicalize()` → `ParseStageStatus("process")` → **error**
2. Since decode failed, the engine silently fell back to the handler's default outcome (typically `success`)
3. Edge conditions like `condition="outcome=process"` compared against `"success"` and **never matched**
4. The pipeline either took the wrong route or stalled with no matching edge

## What changed

| File | Change |
|------|--------|
| `runtime/status.go` | `ParseStageStatus` default case now returns `StageStatus(normalized)` instead of error |
| `runtime/status.go` | Added `IsCanonical()` method on `StageStatus` |
| `runtime/status_test.go` | Tests for custom outcomes, canonical detection, and DecodeOutcomeJSON with custom values |
| `cond/cond_test.go` | Tests for edge condition evaluation with custom outcome values |

## Test plan

- [x] `TestParseStageStatus_CustomOutcomes` — custom values like `process`, `done`, `port`, `needs_dod`, `has_dod`, `yes` all parse correctly (normalized to lowercase)
- [x] `TestStageStatus_IsCanonical` — canonical statuses return true, custom values return false
- [x] `TestDecodeOutcomeJSON_CustomOutcome_Canonical` — `{"status":"process"}` decodes correctly
- [x] `TestDecodeOutcomeJSON_CustomOutcome_Legacy` — `{"outcome":"done"}` decodes correctly
- [x] `TestEvaluate_CustomOutcome` — `outcome=process` matches when status is "process", doesn't match "done"
- [x] All 111 existing engine tests pass unchanged
- [x] All validate tests pass unchanged
- [x] Empty string status still returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)