### PR TITLE
fix: scope verify-node lint to changed files via $base_sha

### DIFF
--- a/internal/attractor/engine/engine.go
+++ b/internal/attractor/engine/engine.go
@@ -305,6 +305,11 @@ func (e *Engine) run(ctx context.Context) (res *Result, err error) {
 		e.Context.Set("graph."+k, v)
 	}
 	e.Context.Set("graph.goal", e.Graph.Attrs["goal"])
+	e.Context.Set("base_sha", baseSHA)
+
+	// Expand $base_sha in prompts now that the base SHA is known.
+	// ($goal was already expanded at parse/prepare time.)
+	expandBaseSHA(e.Graph, baseSHA)
 
 	// Capture the original logs root for loop_restart (attractor-spec §3.2 Step 7).
 	e.baseLogsRoot = e.LogsRoot
@@ -615,6 +620,7 @@ func (e *Engine) loopRestart(ctx context.Context, targetNodeID string, fromNodeI
 		e.Context.Set("graph."+k, v)
 	}
 	e.Context.Set("graph.goal", e.Graph.Attrs["goal"])
+	e.Context.Set("base_sha", e.baseSHA)
 
 	// Reset fidelity state.
 	e.incomingEdge = nil
@@ -1097,6 +1103,25 @@ func expandGoal(g *model.Graph) {
 		}
 		if p := n.Attrs["llm_prompt"]; strings.Contains(p, "$goal") {
 			n.Attrs["llm_prompt"] = strings.ReplaceAll(p, "$goal", goal)
+		}
+	}
+}
+
+// expandBaseSHA replaces $base_sha placeholders in all node prompts. Called after
+// the run's base SHA is known (later than $goal expansion which happens at parse time).
+func expandBaseSHA(g *model.Graph, baseSHA string) {
+	if baseSHA == "" {
+		return
+	}
+	for _, n := range g.Nodes {
+		if n == nil {
+			continue
+		}
+		if p := n.Attrs["prompt"]; strings.Contains(p, "$base_sha") {
+			n.Attrs["prompt"] = strings.ReplaceAll(p, "$base_sha", baseSHA)
+		}
+		if p := n.Attrs["llm_prompt"]; strings.Contains(p, "$base_sha") {
+			n.Attrs["llm_prompt"] = strings.ReplaceAll(p, "$base_sha", baseSHA)
 		}
 	}
 }

--- a/internal/attractor/engine/prepare_test.go
+++ b/internal/attractor/engine/prepare_test.go
@@ -20,3 +20,52 @@ digraph G {
 	}
 }
 
+func TestExpandBaseSHA_ReplacesPlaceholder(t *testing.T) {
+	g, _, err := Prepare([]byte(`
+digraph G {
+  graph [goal="Build it"]
+  start [shape=Mdiamond]
+  exit  [shape=Msquare]
+  verify [shape=box, llm_provider=openai, llm_model=gpt-5.2, prompt="Lint changed files: git diff --name-only $base_sha | xargs eslint"]
+  start -> verify -> exit
+}
+`))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	// $base_sha should still be present after Prepare (expanded at Run time, not parse time).
+	if got := g.Nodes["verify"].Attr("prompt", ""); got != "Lint changed files: git diff --name-only $base_sha | xargs eslint" {
+		t.Fatalf("before expandBaseSHA: prompt = %q", got)
+	}
+
+	expandBaseSHA(g, "abc123def")
+
+	want := "Lint changed files: git diff --name-only abc123def | xargs eslint"
+	if got := g.Nodes["verify"].Attr("prompt", ""); got != want {
+		t.Fatalf("after expandBaseSHA: prompt = %q, want %q", got, want)
+	}
+}
+
+func TestExpandBaseSHA_NoOpWhenEmpty(t *testing.T) {
+	g, _, err := Prepare([]byte(`
+digraph G {
+  graph [goal="Build it"]
+  start [shape=Mdiamond]
+  exit  [shape=Msquare]
+  a [shape=box, llm_provider=openai, llm_model=gpt-5.2, prompt="Check $base_sha here"]
+  start -> a -> exit
+}
+`))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	expandBaseSHA(g, "")
+
+	// Should be unchanged when baseSHA is empty.
+	if got := g.Nodes["a"].Attr("prompt", ""); got != "Check $base_sha here" {
+		t.Fatalf("expandBaseSHA with empty SHA changed prompt: %q", got)
+	}
+}
+

--- a/internal/attractor/gitutil/git.go
+++ b/internal/attractor/gitutil/git.go
@@ -143,6 +143,21 @@ func FastForwardFFOnly(worktreeDir, otherRef string) error {
 	return MergeFastForwardOnly(worktreeDir, otherRef)
 }
 
+// DiffNameOnly returns file paths changed between baseRef and HEAD in the given directory.
+func DiffNameOnly(dir, baseRef string) ([]string, error) {
+	out, _, err := runGit(dir, "diff", "--name-only", baseRef)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+	return files, nil
+}
+
 func ensureUserIdentity(worktreeDir string) error {
 	name, _, err := runGit(worktreeDir, "config", "--get", "user.name")
 	if err != nil {

--- a/internal/attractor/gitutil/git_test.go
+++ b/internal/attractor/gitutil/git_test.go
@@ -1,0 +1,91 @@
+package gitutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.name", "test")
+	run("config", "user.email", "test@test")
+	// Initial commit.
+	if err := os.WriteFile(filepath.Join(dir, "initial.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "initial")
+	return dir
+}
+
+func TestDiffNameOnly(t *testing.T) {
+	dir := initTestRepo(t)
+
+	baseSHA, err := HeadSHA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new file and commit it.
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", dir, "add", "-A")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	cmd = exec.Command("git", "-C", dir, "commit", "-m", "add new file")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	files, err := DiffNameOnly(dir, baseSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 1 || files[0] != "new.txt" {
+		t.Errorf("DiffNameOnly = %v, want [new.txt]", files)
+	}
+}
+
+func TestDiffNameOnly_NoChanges(t *testing.T) {
+	dir := initTestRepo(t)
+
+	sha, err := HeadSHA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := DiffNameOnly(dir, sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("DiffNameOnly with no changes = %v, want []", files)
+	}
+}


### PR DESCRIPTION
## Summary

- Verify nodes generated by the `english-to-dotfile` skill currently run lint on the **entire project**, causing pre-existing lint errors in unrelated files to fail the verify gate and trap the attractor in an infinite retry loop.
- This PR introduces `$base_sha` as a run-time prompt variable (the HEAD commit SHA from before any changes) so verify prompts can scope lint to only changed files (e.g. `git diff --name-only $base_sha | xargs eslint`).
- Adds a `DiffNameOnly` helper to `gitutil` for downstream use and updates the skill template to generate scoped lint commands by default.

## Changes

### `internal/attractor/gitutil/git.go`
- Added `DiffNameOnly(dir, baseRef)` — returns file paths changed between `baseRef` and HEAD.

### `internal/attractor/gitutil/git_test.go` *(new)*
- Tests for `DiffNameOnly`: verifies changed files are detected, and no-change case returns empty.

### `internal/attractor/engine/engine.go`
- Added `expandBaseSHA(g, baseSHA)` function that replaces `$base_sha` placeholders in node `prompt` and `llm_prompt` attributes at run time (after the base SHA is known).
- Set `base_sha` in the engine context at run start and on loop restart.

### `internal/attractor/engine/prepare_test.go`
- Added `TestExpandBaseSHA_ReplacesPlaceholder` and `TestExpandBaseSHA_NoOpWhenEmpty`.

### `skills/english-to-dotfile/SKILL.md`
- Updated validation scope policy with language-agnostic lint scoping guidance.
- Updated verify prompt template to use `git diff --name-only $base_sha` instead of project-wide lint.
- Added anti-pattern #18 (unscoped lint in verify nodes).
- Updated example pipeline verify nodes and `prompt` attribute description.

## Test plan

- [x] `go test ./internal/attractor/gitutil/...` — passes (2 new tests)
- [x] `go test ./internal/attractor/engine/...` — new tests pass; 2 pre-existing failures (`ForceModel`, `WaitWithIdleWatchdog`) confirmed on clean `main`
- [x] `go vet ./...` — clean
- [ ] Manual: run attractor on a project with pre-existing lint errors and confirm verify gate passes when new code is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)