### PR TITLE
feat(engine): push run branch to remote on loop_restart

### DIFF
--- a/internal/attractor/engine/config.go
+++ b/internal/attractor/engine/config.go
@@ -75,6 +75,7 @@ type RunConfigFile struct {
 		RequireClean    bool   `json:"require_clean" yaml:"require_clean"`
 		RunBranchPrefix string `json:"run_branch_prefix" yaml:"run_branch_prefix"`
 		CommitPerNode   bool   `json:"commit_per_node" yaml:"commit_per_node"`
+		PushRemote      string `json:"push_remote,omitempty" yaml:"push_remote,omitempty"`
 	} `json:"git" yaml:"git"`
 }
 

--- a/internal/attractor/engine/engine.go
+++ b/internal/attractor/engine/engine.go
@@ -580,6 +580,9 @@ func (e *Engine) loopRestart(ctx context.Context, targetNodeID string, fromNodeI
 		return nil, fmt.Errorf("loop_restart limit exceeded (%d restarts, max %d)", e.restartCount, maxRestarts)
 	}
 
+	// Best-effort push before starting fresh iteration so remote has completed work.
+	e.gitPushIfConfigured()
+
 	// Create a fresh log sub-directory for this iteration.
 	newLogsRoot := filepath.Join(e.baseLogsRoot, fmt.Sprintf("restart-%d", e.restartCount))
 	if err := os.MkdirAll(newLogsRoot, 0o755); err != nil {
@@ -1008,6 +1011,49 @@ func (e *Engine) persistTerminalOutcome(ctx context.Context, final runtime.Final
 	}
 
 	e.terminalOutcomePersisted = true
+
+	// Best-effort push after terminal outcome so remote has final state.
+	e.gitPushIfConfigured()
+}
+
+// gitPushIfConfigured pushes the run branch to the configured remote.
+// It is best-effort: failures are logged as warnings but never abort the run.
+func (e *Engine) gitPushIfConfigured() {
+	if e == nil || e.RunConfig == nil {
+		return
+	}
+	remote := strings.TrimSpace(e.RunConfig.Git.PushRemote)
+	if remote == "" {
+		return
+	}
+	branch := strings.TrimSpace(e.RunBranch)
+	if branch == "" {
+		return
+	}
+	repoDir := strings.TrimSpace(e.Options.RepoPath)
+	if repoDir == "" {
+		return
+	}
+	e.appendProgress(map[string]any{
+		"event":  "git_push_start",
+		"remote": remote,
+		"branch": branch,
+	})
+	if err := gitutil.PushBranch(repoDir, remote, branch); err != nil {
+		e.Warn(fmt.Sprintf("git push %s %s: %v", remote, branch, err))
+		e.appendProgress(map[string]any{
+			"event":  "git_push_failed",
+			"remote": remote,
+			"branch": branch,
+			"error":  err.Error(),
+		})
+		return
+	}
+	e.appendProgress(map[string]any{
+		"event":  "git_push_ok",
+		"remote": remote,
+		"branch": branch,
+	})
 }
 
 func (e *Engine) finalOutcomePaths() []string {

--- a/internal/attractor/engine/git_push_test.go
+++ b/internal/attractor/engine/git_push_test.go
@@ -1,0 +1,147 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/strongdm/kilroy/internal/attractor/model"
+	"github.com/strongdm/kilroy/internal/attractor/runtime"
+)
+
+func TestGitPushIfConfigured_NoPushRemote(t *testing.T) {
+	eng := &Engine{
+		RunConfig: &RunConfigFile{},
+	}
+	// Should be a no-op (no panic, no error).
+	eng.gitPushIfConfigured()
+}
+
+func TestGitPushIfConfigured_NilRunConfig(t *testing.T) {
+	eng := &Engine{}
+	eng.gitPushIfConfigured()
+}
+
+func TestGitPushIfConfigured_NilEngine(t *testing.T) {
+	var eng *Engine
+	eng.gitPushIfConfigured()
+}
+
+func TestGitPushIfConfigured_PushesToRemote(t *testing.T) {
+	// Set up a source repo with one commit.
+	repo := t.TempDir()
+	runCmd(t, repo, "git", "init")
+	runCmd(t, repo, "git", "config", "user.name", "tester")
+	runCmd(t, repo, "git", "config", "user.email", "tester@example.com")
+	_ = os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644)
+	runCmd(t, repo, "git", "add", "-A")
+	runCmd(t, repo, "git", "commit", "-m", "init")
+
+	// Create a branch to push.
+	runCmd(t, repo, "git", "branch", "attractor/run/test-push", "HEAD")
+
+	// Set up a bare remote.
+	bare := t.TempDir()
+	runCmd(t, bare, "git", "init", "--bare")
+	runCmd(t, repo, "git", "remote", "add", "test-remote", bare)
+
+	eng := &Engine{
+		Options:   RunOptions{RepoPath: repo},
+		RunBranch: "attractor/run/test-push",
+		RunConfig: &RunConfigFile{},
+	}
+	eng.RunConfig.Git.PushRemote = "test-remote"
+
+	eng.gitPushIfConfigured()
+
+	// Verify the branch exists on the remote.
+	out := runCmdOut(t, bare, "git", "branch", "--list", "attractor/run/test-push")
+	if !strings.Contains(out, "attractor/run/test-push") {
+		t.Fatalf("expected branch on remote, got: %q", out)
+	}
+}
+
+func TestLoopRestart_PushesOnRestart(t *testing.T) {
+	repo := t.TempDir()
+	runCmd(t, repo, "git", "init")
+	runCmd(t, repo, "git", "config", "user.name", "tester")
+	runCmd(t, repo, "git", "config", "user.email", "tester@example.com")
+	_ = os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644)
+	runCmd(t, repo, "git", "add", "-A")
+	runCmd(t, repo, "git", "commit", "-m", "init")
+
+	// Bare remote to receive pushes.
+	bare := t.TempDir()
+	runCmd(t, bare, "git", "init", "--bare")
+	runCmd(t, repo, "git", "remote", "add", "test-remote", bare)
+
+	dot := []byte(`
+digraph G {
+  graph [goal="test push on restart"]
+  start [shape=Mdiamond]
+  exit  [shape=Msquare]
+  work  [shape=box, llm_provider=openai, llm_model=gpt-5.2, prompt="do work"]
+  check [shape=diamond]
+  start -> work
+  work -> check
+  check -> exit [condition="outcome=success"]
+  check -> work [condition="outcome=fail", loop_restart=true]
+}
+`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var callCount atomic.Int32
+	backend := &countingBackend{
+		fn: func(ctx context.Context, exec *Execution, node *model.Node, prompt string) (string, *runtime.Outcome, error) {
+			n := callCount.Add(1)
+			if node.ID == "work" && n == 1 {
+				return "fail", &runtime.Outcome{Status: runtime.StatusFail, FailureReason: "transient_infra: connection reset"}, nil
+			}
+			return "ok", &runtime.Outcome{Status: runtime.StatusSuccess}, nil
+		},
+	}
+
+	g, _, err := Prepare(dot)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	logsRoot := t.TempDir()
+	cfg := &RunConfigFile{}
+	cfg.Version = 1
+	cfg.Git.PushRemote = "test-remote"
+
+	eng := &Engine{
+		Graph:           g,
+		Options:         RunOptions{RepoPath: repo, RunID: "test-push-restart", LogsRoot: logsRoot, WorktreeDir: filepath.Join(logsRoot, "worktree"), RunBranchPrefix: "attractor/run", RequireClean: true},
+		DotSource:       dot,
+		LogsRoot:        logsRoot,
+		WorktreeDir:     filepath.Join(logsRoot, "worktree"),
+		Context:         runtime.NewContext(),
+		Registry:        NewDefaultRegistry(),
+		Interviewer:     &AutoApproveInterviewer{},
+		CodergenBackend: backend,
+		RunConfig:       cfg,
+	}
+	eng.RunBranch = "attractor/run/test-push-restart"
+
+	res, err := eng.run(ctx)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.FinalStatus != runtime.FinalSuccess {
+		t.Fatalf("expected final status success, got %s", res.FinalStatus)
+	}
+
+	// Verify the branch was pushed to the remote.
+	out := runCmdOut(t, bare, "git", "branch", "--list", "attractor/run/test-push-restart")
+	if !strings.Contains(out, "attractor/run/test-push-restart") {
+		t.Fatalf("expected branch on remote after loop_restart, got: %q", out)
+	}
+}

--- a/internal/attractor/gitutil/git.go
+++ b/internal/attractor/gitutil/git.go
@@ -132,6 +132,13 @@ func CommitAllowEmpty(worktreeDir, message string) (string, error) {
 	return HeadSHA(worktreeDir)
 }
 
+// PushBranch pushes a branch to the specified remote.
+// It is a best-effort operation; failures are returned but should not abort a run.
+func PushBranch(repoDir, remote, branch string) error {
+	_, _, err := runGit(repoDir, "push", remote, branch)
+	return err
+}
+
 func MergeFastForwardOnly(worktreeDir, otherRef string) error {
 	_, _, err := runGit(worktreeDir, "merge", "--ff-only", otherRef)
 	return err


### PR DESCRIPTION
## Summary

- Adds optional `git.push_remote` config field to run config
- Pushes the run branch to the configured remote on each `loop_restart` (before starting fresh iteration) and on terminal outcome persistence
- Push is best-effort: failures are logged as warnings + progress events (`git_push_start`, `git_push_ok`, `git_push_failed`) but never abort the run
- Adds `gitutil.PushBranch` helper and `Engine.gitPushIfConfigured` method

## Motivation

During long-running autonomous pipeline executions (e.g., feature factories that loop for hours), all committed work lives only on the local run branch until the user manually pushes. If the machine dies, hours of work are lost. This change ensures completed work is pushed to a remote after each successful loop iteration.

## Usage

```yaml
git:
  push_remote: origin  # optional; omit to disable auto-push
```

## Test plan

- [x] `TestGitPushIfConfigured_NoPushRemote` - no-op when push_remote is empty
- [x] `TestGitPushIfConfigured_NilRunConfig` - no-op when config is nil
- [x] `TestGitPushIfConfigured_NilEngine` - no-op on nil receiver
- [x] `TestGitPushIfConfigured_PushesToRemote` - verifies branch appears on bare remote
- [x] `TestLoopRestart_PushesOnRestart` - full integration: loop_restart triggers push to bare remote
- [x] `go vet` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)