### PR TITLE
feat(engine): add pre-run setup_commands config

### DIFF
--- a/internal/attractor/engine/config.go
+++ b/internal/attractor/engine/config.go
@@ -76,6 +76,11 @@ type RunConfigFile struct {
 		RunBranchPrefix string `json:"run_branch_prefix" yaml:"run_branch_prefix"`
 		CommitPerNode   bool   `json:"commit_per_node" yaml:"commit_per_node"`
 	} `json:"git" yaml:"git"`
+
+	Setup struct {
+		Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+		TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+	} `json:"setup,omitempty" yaml:"setup,omitempty"`
 }
 
 func LoadRunConfigFile(path string) (*RunConfigFile, error) {
@@ -146,6 +151,9 @@ func applyConfigDefaults(cfg *RunConfigFile) {
 	}
 	if cfg.CXDB.Autostart.PollIntervalMS == 0 {
 		cfg.CXDB.Autostart.PollIntervalMS = 250
+	}
+	if cfg.Setup.TimeoutMS == 0 {
+		cfg.Setup.TimeoutMS = 300000 // 5 minutes
 	}
 	cfg.CXDB.Autostart.Command = trimNonEmpty(cfg.CXDB.Autostart.Command)
 	cfg.CXDB.Autostart.UI.Command = trimNonEmpty(cfg.CXDB.Autostart.UI.Command)

--- a/internal/attractor/engine/engine.go
+++ b/internal/attractor/engine/engine.go
@@ -315,6 +315,11 @@ func (e *Engine) run(ctx context.Context) (res *Result, err error) {
 	// ($goal was already expanded at parse/prepare time.)
 	expandBaseSHA(e.Graph, baseSHA)
 
+	// Run pre-pipeline setup commands (e.g., npm install) in the worktree.
+	if err := e.executeSetupCommands(ctx); err != nil {
+		return nil, fmt.Errorf("setup commands failed: %w", err)
+	}
+
 	// Capture the original logs root for loop_restart (attractor-spec §3.2 Step 7).
 	e.baseLogsRoot = e.LogsRoot
 

--- a/internal/attractor/engine/setup_commands.go
+++ b/internal/attractor/engine/setup_commands.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// executeSetupCommands runs the configured setup commands sequentially in the
+// worktree directory before the first pipeline node executes. Commands are run
+// via "sh -c" and fail fast on the first error.
+func (e *Engine) executeSetupCommands(ctx context.Context) error {
+	if e == nil || e.RunConfig == nil || len(e.RunConfig.Setup.Commands) == 0 {
+		return nil
+	}
+
+	timeoutMS := e.RunConfig.Setup.TimeoutMS
+	if timeoutMS <= 0 {
+		timeoutMS = 300000
+	}
+	timeout := time.Duration(timeoutMS) * time.Millisecond
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for i, cmdStr := range e.RunConfig.Setup.Commands {
+		cmdStr = strings.TrimSpace(cmdStr)
+		if cmdStr == "" {
+			continue
+		}
+
+		e.appendProgress(map[string]any{
+			"event":   "setup_command_start",
+			"index":   i,
+			"command": cmdStr,
+		})
+
+		cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+		cmd.Dir = e.WorktreeDir
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		if err != nil {
+			e.appendProgress(map[string]any{
+				"event":   "setup_command_failed",
+				"index":   i,
+				"command": cmdStr,
+				"error":   err.Error(),
+				"stdout":  strings.TrimSpace(stdout.String()),
+				"stderr":  strings.TrimSpace(stderr.String()),
+			})
+			return fmt.Errorf("setup command [%d] %q failed: %w", i, cmdStr, err)
+		}
+
+		e.appendProgress(map[string]any{
+			"event":   "setup_command_ok",
+			"index":   i,
+			"command": cmdStr,
+			"stdout":  strings.TrimSpace(stdout.String()),
+		})
+	}
+
+	return nil
+}

--- a/internal/attractor/engine/setup_commands_test.go
+++ b/internal/attractor/engine/setup_commands_test.go
@@ -1,0 +1,201 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSetupCommands_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	e := &Engine{
+		LogsRoot:    dir,
+		WorktreeDir: dir,
+		Options:     RunOptions{RunID: "test-no-config"},
+	}
+
+	// No RunConfig at all — should be a no-op.
+	if err := e.executeSetupCommands(context.Background()); err != nil {
+		t.Fatalf("expected no error with nil RunConfig, got: %v", err)
+	}
+
+	// RunConfig with empty commands — should be a no-op.
+	e.RunConfig = &RunConfigFile{}
+	if err := e.executeSetupCommands(context.Background()); err != nil {
+		t.Fatalf("expected no error with empty commands, got: %v", err)
+	}
+}
+
+func TestSetupCommands_RunsInWorktree(t *testing.T) {
+	worktree := t.TempDir()
+	logsRoot := t.TempDir()
+
+	e := &Engine{
+		LogsRoot:    logsRoot,
+		WorktreeDir: worktree,
+		Options:     RunOptions{RunID: "test-worktree"},
+		RunConfig: &RunConfigFile{
+			Setup: struct {
+				Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+				TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+			}{
+				Commands:  []string{"pwd > cwd.txt"},
+				TimeoutMS: 10000,
+			},
+		},
+	}
+
+	if err := e.executeSetupCommands(context.Background()); err != nil {
+		t.Fatalf("executeSetupCommands failed: %v", err)
+	}
+
+	// Verify the command ran inside the worktree directory.
+	b, err := os.ReadFile(filepath.Join(worktree, "cwd.txt"))
+	if err != nil {
+		t.Fatalf("expected cwd.txt in worktree: %v", err)
+	}
+	got := strings.TrimSpace(string(b))
+	if got != worktree {
+		t.Fatalf("command ran in %q, expected %q", got, worktree)
+	}
+}
+
+func TestSetupCommands_FailsOnError(t *testing.T) {
+	logsRoot := t.TempDir()
+	worktree := t.TempDir()
+
+	e := &Engine{
+		LogsRoot:    logsRoot,
+		WorktreeDir: worktree,
+		Options:     RunOptions{RunID: "test-fail"},
+		RunConfig: &RunConfigFile{
+			Setup: struct {
+				Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+				TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+			}{
+				Commands:  []string{"false"},
+				TimeoutMS: 10000,
+			},
+		},
+	}
+
+	err := e.executeSetupCommands(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "setup command [0]") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestSetupCommands_MultipleCommands(t *testing.T) {
+	worktree := t.TempDir()
+	logsRoot := t.TempDir()
+
+	e := &Engine{
+		LogsRoot:    logsRoot,
+		WorktreeDir: worktree,
+		Options:     RunOptions{RunID: "test-multi"},
+		RunConfig: &RunConfigFile{
+			Setup: struct {
+				Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+				TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+			}{
+				Commands: []string{
+					"echo first > first.txt",
+					"echo second > second.txt",
+					"echo third > third.txt",
+				},
+				TimeoutMS: 10000,
+			},
+		},
+	}
+
+	if err := e.executeSetupCommands(context.Background()); err != nil {
+		t.Fatalf("executeSetupCommands failed: %v", err)
+	}
+
+	// All three files should exist.
+	for _, name := range []string{"first.txt", "second.txt", "third.txt"} {
+		b, err := os.ReadFile(filepath.Join(worktree, name))
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+		if strings.TrimSpace(string(b)) == "" {
+			t.Fatalf("%s is empty", name)
+		}
+	}
+}
+
+func TestSetupCommands_FailsOnError_StopsEarly(t *testing.T) {
+	worktree := t.TempDir()
+	logsRoot := t.TempDir()
+
+	e := &Engine{
+		LogsRoot:    logsRoot,
+		WorktreeDir: worktree,
+		Options:     RunOptions{RunID: "test-stop-early"},
+		RunConfig: &RunConfigFile{
+			Setup: struct {
+				Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+				TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+			}{
+				Commands: []string{
+					"echo before > before.txt",
+					"false",
+					"echo after > after.txt",
+				},
+				TimeoutMS: 10000,
+			},
+		},
+	}
+
+	err := e.executeSetupCommands(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// First command should have run.
+	if _, err := os.Stat(filepath.Join(worktree, "before.txt")); err != nil {
+		t.Fatalf("before.txt should exist: %v", err)
+	}
+	// Third command should NOT have run.
+	if _, err := os.Stat(filepath.Join(worktree, "after.txt")); err == nil {
+		t.Fatal("after.txt should not exist (fail-fast)")
+	}
+}
+
+func TestSetupCommands_Timeout(t *testing.T) {
+	worktree := t.TempDir()
+	logsRoot := t.TempDir()
+
+	e := &Engine{
+		LogsRoot:    logsRoot,
+		WorktreeDir: worktree,
+		Options:     RunOptions{RunID: "test-timeout"},
+		RunConfig: &RunConfigFile{
+			Setup: struct {
+				Commands  []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+				TimeoutMS int      `json:"timeout_ms,omitempty" yaml:"timeout_ms,omitempty"`
+			}{
+				Commands:  []string{"sleep 30"},
+				TimeoutMS: 200, // 200ms timeout
+			},
+		},
+	}
+
+	start := time.Now()
+	err := e.executeSetupCommands(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	// Should complete well under 5s (the sleep is 30s, timeout is 200ms).
+	if elapsed > 5*time.Second {
+		t.Fatalf("timeout took too long: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `setup` config section with `commands` (string array) and `timeout_ms` (default 5 min) to `RunConfigFile`
- New `executeSetupCommands` method runs each command sequentially via `sh -c` in the worktree before the first pipeline node executes
- Solves the problem where Codex's sandbox can't reach `registry.npmjs.org` during autonomous pipeline runs — `npm install` must happen before the pipeline starts

## Example config
```yaml
setup:
  commands:
    - npm install
    - npx playwright install
  timeout_ms: 600000
```

## Test plan
- [x] `TestSetupCommands_NoConfig` — no-op when no commands configured
- [x] `TestSetupCommands_RunsInWorktree` — verify command runs in worktree dir
- [x] `TestSetupCommands_FailsOnError` — bad command aborts run
- [x] `TestSetupCommands_MultipleCommands` — runs sequentially, all execute
- [x] `TestSetupCommands_FailsOnError_StopsEarly` — fail-fast stops subsequent commands
- [x] `TestSetupCommands_Timeout` — respects timeout config
- [x] All existing engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)