### PR TITLE
fix(engine): enrich timeout outcomes with diagnostic metadata

### DIFF
--- a/internal/attractor/engine/engine.go
+++ b/internal/attractor/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	rdebug "runtime/debug"
 	"sort"
@@ -802,6 +803,24 @@ func (e *Engine) executeNode(ctx context.Context, node *model.Node) (runtime.Out
 			out.FailureReason = cause.Error()
 		}
 	}
+	// Enrich timeout outcomes with diagnostic metadata so downstream consumers
+	// know the node timed out (vs. crashed) and what state the worktree was left in.
+	// This runs after status.json is read so it applies regardless of handler path.
+	if (out.Status == runtime.StatusFail || out.Status == runtime.StatusRetry) && ctx.Err() == context.DeadlineExceeded {
+		if out.Meta == nil {
+			out.Meta = map[string]any{}
+		}
+		out.Meta["timeout"] = true
+		if timeout := effectiveStageTimeout(node, e.Options.StageTimeout); timeout > 0 {
+			out.Meta["timeout_seconds"] = int(timeout.Seconds())
+		}
+		partial := e.harvestPartialStatus(stageDir, node)
+		if partial != nil {
+			out.Meta["partial_status"] = partial
+			_ = writeJSON(filepath.Join(stageDir, "partial_status.json"), partial)
+		}
+	}
+
 	// Ensure required fields are present.
 	if out.ContextUpdates == nil {
 		out.ContextUpdates = map[string]any{}
@@ -820,6 +839,32 @@ func (e *Engine) executeNode(ctx context.Context, node *model.Node) (runtime.Out
 	// Write status.json (canonical metaspec shape).
 	_ = writeJSON(filepath.Join(stageDir, "status.json"), out)
 	return out, nil
+}
+
+// harvestPartialStatus checks the worktree after a timeout to determine what
+// state the node left behind. This is best-effort diagnostic data — it never
+// blocks or fails the run.
+func (e *Engine) harvestPartialStatus(stageDir string, node *model.Node) map[string]any {
+	if e.WorktreeDir == "" {
+		return nil
+	}
+	partial := map[string]any{
+		"node_id":   node.ID,
+		"harvested": true,
+	}
+	// Count files changed in worktree relative to HEAD.
+	diffOut, err := exec.CommandContext(context.Background(), "git", "-C", e.WorktreeDir, "diff", "--name-only", "HEAD").Output()
+	if err == nil {
+		lines := strings.Split(strings.TrimSpace(string(diffOut)), "\n")
+		changed := 0
+		for _, l := range lines {
+			if strings.TrimSpace(l) != "" {
+				changed++
+			}
+		}
+		partial["files_changed"] = changed
+	}
+	return partial
 }
 
 func (e *Engine) executeWithRetry(ctx context.Context, node *model.Node, retries map[string]int) (runtime.Outcome, error) {

--- a/internal/attractor/engine/engine_stage_timeout_test.go
+++ b/internal/attractor/engine/engine_stage_timeout_test.go
@@ -2,9 +2,14 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/strongdm/kilroy/internal/attractor/runtime"
 )
 
 // Intentionally uses shape=parallelogram/tool_command because this is the
@@ -44,5 +49,57 @@ func TestRun_GlobalAndNodeTimeout_UsesSmallerTimeout(t *testing.T) {
 	_, err := Run(context.Background(), dot, opts)
 	if err == nil {
 		t.Fatal("expected timeout from node/global min timeout")
+	}
+}
+
+// TestRun_TimeoutOutcomeIncludesMetadata verifies that timed-out nodes get
+// enriched Meta with timeout=true and a partial_status.json diagnostic artifact.
+// Uses StageTimeout (engine-level) rather than node timeout to ensure the engine
+// context deadline fires — the ToolHandler applies node timeout internally.
+func TestRun_TimeoutOutcomeIncludesMetadata(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("requires sleep binary")
+	}
+	dot := []byte(`digraph G {
+  start [shape=Mdiamond]
+  wait [shape=parallelogram, tool_command="sleep 5"]
+  exit [shape=Msquare]
+  start -> wait
+  wait -> exit [condition="outcome=success"]
+}`)
+	repo := initTestRepo(t)
+	logsRoot := t.TempDir()
+	// Use global StageTimeout to set the engine-level context deadline.
+	opts := RunOptions{RepoPath: repo, LogsRoot: logsRoot, StageTimeout: 500 * time.Millisecond}
+	_, _ = Run(context.Background(), dot, opts)
+
+	statusPath := filepath.Join(logsRoot, "wait", "status.json")
+	b, err := os.ReadFile(statusPath)
+	if err != nil {
+		t.Fatalf("read status.json: %v", err)
+	}
+	out, err := runtime.DecodeOutcomeJSON(b)
+	if err != nil {
+		t.Fatalf("decode status.json: %v", err)
+	}
+	if out.Meta == nil {
+		t.Fatal("expected Meta to be populated on timeout outcome")
+	}
+	if v, ok := out.Meta["timeout"]; !ok || v != true {
+		t.Fatalf("Meta[timeout]: got %v want true", out.Meta["timeout"])
+	}
+
+	// Also verify partial_status.json was written.
+	partialPath := filepath.Join(logsRoot, "wait", "partial_status.json")
+	pb, err := os.ReadFile(partialPath)
+	if err != nil {
+		t.Fatalf("read partial_status.json: %v", err)
+	}
+	var partial map[string]any
+	if err := json.Unmarshal(pb, &partial); err != nil {
+		t.Fatalf("unmarshal partial_status.json: %v", err)
+	}
+	if partial["harvested"] != true {
+		t.Fatalf("partial_status.json: expected harvested=true, got %v", partial["harvested"])
 	}
 }


### PR DESCRIPTION
## Summary
- When a node times out, enriches outcome Meta with `timeout: true`, `timeout_seconds`, and `partial_status` (files changed in worktree)
- Writes `partial_status.json` as a diagnostic artifact next to `status.json`
- Adds `harvestPartialStatus()` that checks git diff to count modified files after timeout
- Timeout enrichment runs after status.json read, so it works regardless of handler type (codergen or tool)

## Problem
When `implement_feature` runs for 30 minutes and times out, the engine records a bare retry/fail with no information about what was accomplished. Operators see "context deadline exceeded" but don't know if the build passes, how many files were changed, or whether retrying would be productive. This PR gives timeout outcomes a diagnostic footprint.

## Test plan
- [x] New test `TestRun_TimeoutOutcomeIncludesMetadata` verifies Meta contains `timeout: true` and `partial_status.json` is written
- [x] Existing timeout tests still pass (`TestRun_GlobalStageTimeoutCapsToolNode`, `TestRun_GlobalAndNodeTimeout_UsesSmallerTimeout`)
- [x] `go vet ./internal/attractor/engine/` clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>