### PR TITLE
fix(engine): configurable state-db discrepancy retry with per-attempt logs

### DIFF
--- a/internal/attractor/engine/codergen_state_db_test.go
+++ b/internal/attractor/engine/codergen_state_db_test.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestCodexStateDBMaxRetries_Default(t *testing.T) {
+	t.Setenv("KILROY_CODEX_STATE_DB_MAX_RETRIES", "")
+	if got := codexStateDBMaxRetries(); got != 2 {
+		t.Fatalf("default: got %d want 2", got)
+	}
+}
+
+func TestCodexStateDBMaxRetries_Configured(t *testing.T) {
+	t.Setenv("KILROY_CODEX_STATE_DB_MAX_RETRIES", "3")
+	if got := codexStateDBMaxRetries(); got != 3 {
+		t.Fatalf("configured: got %d want 3", got)
+	}
+}
+
+func TestCodexStateDBMaxRetries_Zero(t *testing.T) {
+	t.Setenv("KILROY_CODEX_STATE_DB_MAX_RETRIES", "0")
+	if got := codexStateDBMaxRetries(); got != 0 {
+		t.Fatalf("zero: got %d want 0", got)
+	}
+}
+
+func TestCodexStateDBMaxRetries_InvalidFallsBackToDefault(t *testing.T) {
+	t.Setenv("KILROY_CODEX_STATE_DB_MAX_RETRIES", "not-a-number")
+	if got := codexStateDBMaxRetries(); got != 2 {
+		t.Fatalf("invalid: got %d want 2", got)
+	}
+}
+
+func TestIsStateDBDiscrepancy(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{"missing rollout", "Error: state db missing rollout path for ...", true},
+		{"record discrepancy", "state db record_discrepancy detected", true},
+		{"no match", "some other error", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStateDBDiscrepancy(tc.stderr); got != tc.want {
+				t.Fatalf("isStateDBDiscrepancy(%q): got %v want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces hardcoded single state-db retry with configurable loop (default 2 retries)
- Each retry uses a fresh isolated home directory (`codex-home-retryN`)
- Saves numbered failure logs per attempt (`stdout/stderr.state_db_failure_N.log`)
- Records `state_db_retry_attempt` in `cli_invocation.json`
- Configurable via `KILROY_CODEX_STATE_DB_MAX_RETRIES` (set to `0` to disable)

## Problem
When codex hits a state-db discrepancy, the engine retries once with a fresh state root. If the retry also fails, it consumes a node-level retry. In a recent esperaudience-factory run, this cost 2 of 4 verify_feature attempts. Handling state-db issues at the codex layer prevents them from wasting stage retries.

## Test plan
- [x] `TestCodexStateDBMaxRetries_Default` — default is 2
- [x] `TestCodexStateDBMaxRetries_Configured` — respects env var
- [x] `TestCodexStateDBMaxRetries_Zero` — can be disabled
- [x] `TestCodexStateDBMaxRetries_InvalidFallsBackToDefault` — bad input falls back
- [x] `TestIsStateDBDiscrepancy` — pattern matching for all known signatures
- [x] `go vet ./internal/attractor/engine/` clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>