### PR TITLE
fix(engine): persist specified context keys across loop_restart

### DIFF
--- a/internal/attractor/engine/loop_restart_policy.go
+++ b/internal/attractor/engine/loop_restart_policy.go
@@ -130,6 +130,26 @@ func restartFailureSignature(nodeID string, out runtime.Outcome, failureClass st
 	return strings.TrimSpace(nodeID) + "|" + normalizedFailureClassOrDefault(failureClass) + "|" + reason
 }
 
+// loopRestartPersistKeyNames returns the list of context keys configured to persist
+// across loop_restart iterations via the loop_restart_persist_keys graph attribute.
+func loopRestartPersistKeyNames(g *model.Graph) []string {
+	if g == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(g.Attrs["loop_restart_persist_keys"])
+	if raw == "" {
+		return nil
+	}
+	var keys []string
+	for _, key := range strings.Split(raw, ",") {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 func normalizeFailureReason(reason string) string {
 	reason = strings.ToLower(strings.TrimSpace(reason))
 	if reason == "" {


### PR DESCRIPTION
## Summary
- Add `loop_restart_persist_keys` graph attribute (comma-separated context keys to preserve across restarts)
- Inject `loop_restart.iteration_count` and `loop_restart.from_node` into post-restart context
- Progress events now include `persist_keys` field for observability

## Problem
The factory dies on stuck features because `loopRestart()` resets all context between iterations. This prevents pipelines from tracking which features have been attempted, causing the same stuck feature to be picked repeatedly across loop restarts until `max_restarts` is hit.

With this fix, pipelines can specify keys like `completed_features,skipped_features` in the graph attribute, and the pick_feature node can use the accumulated state to skip features that keep failing.

## Usage
```dot
digraph G {
  graph [
    goal="implement features",
    loop_restart_persist_keys="completed_features,skipped_features,feature_attempt_counts"
  ]
  // ... pipeline nodes ...
}
```

After a loop_restart, the context will contain:
- All keys listed in `loop_restart_persist_keys` (with values from the previous iteration)
- `loop_restart.iteration_count` — number of restarts so far
- `loop_restart.from_node` — the node that triggered the restart

## Test plan
- [x] New test: `TestLoopRestart_PersistsContextKeys` — verifies listed keys persist, unlisted keys don't, and metadata injected
- [x] New test: `TestLoopRestart_PersistKeysProgressEvent` — verifies progress event includes persist_keys
- [x] All 10 loop_restart tests pass (no regressions)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)