### PR TITLE
fix(engine): classify codex stream disconnects as transient_infra

### DIFF
--- a/internal/attractor/engine/loop_restart_policy.go
+++ b/internal/attractor/engine/loop_restart_policy.go
@@ -40,6 +40,8 @@ var (
 		"econnreset",
 		"dial tcp",
 		"transport is closing",
+		"stream disconnected",
+		"stream closed before",
 		"502",
 		"503",
 		"504",

--- a/internal/attractor/engine/loop_restart_test.go
+++ b/internal/attractor/engine/loop_restart_test.go
@@ -525,6 +525,29 @@ digraph G {
 	}
 }
 
+func TestClassifyFailureClass_StreamDisconnectIsTransient(t *testing.T) {
+	cases := []struct {
+		reason    string
+		wantClass string
+	}{
+		{"codex stream disconnected before completion", failureClassTransientInfra},
+		{"stream closed before response.completed", failureClassTransientInfra},
+		{"exit status 1", failureClassDeterministic},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			out := runtime.Outcome{
+				Status:        runtime.StatusFail,
+				FailureReason: tc.reason,
+			}
+			got := classifyFailureClass(out)
+			if got != tc.wantClass {
+				t.Fatalf("classifyFailureClass(%q): got %q want %q", tc.reason, got, tc.wantClass)
+			}
+		})
+	}
+}
+
 func readProgressEvents(t *testing.T, path string) []map[string]any {
 	t.Helper()
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary
- Codex CLI exits with generic "exit status 1" when OpenAI's API stream disconnects mid-response (e.g., `stream disconnected before completion: stream closed before response.completed`)
- The stderr-only error classifier couldn't distinguish this from deterministic failures, causing the loop_restart circuit breaker to halt the entire run after 3 identical signatures
- Observed in production: factory run 01KH43RQA4RBSQY2DSVHZX9C5B completed feature 1, then died on feature 2 due to repeated OpenAI stream disconnects being misclassified as deterministic

Three-layer fix:
1. **codergen_router**: scan codex stdout NDJSON events for stream disconnect evidence before falling through to the stderr-only classifier, reclassifying as `transient_infra` with signature `provider_stream_disconnect|<provider>|stream_closed`
2. **provider_error_classification**: add `looksLikeStreamDisconnect()` to detect "stream disconnected" / "stream closed before" patterns in stdout
3. **loop_restart_policy**: add stream disconnect phrases to `transientInfraReasonHints` as defense-in-depth for the failure reason heuristic layer

## Test plan
- [x] `TestLooksLikeStreamDisconnect` — 5 cases covering empty, normal output, various disconnect patterns
- [x] `TestClassifyFailureClass_StreamDisconnectIsTransient` — 3 cases verifying failure reason heuristic layer
- [x] Full engine test suite passes (1 pre-existing unrelated failure in `ForceModel_BypassesCatalogGate`)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)