### PR TITLE
feat(engine): add prompt_file attribute for external prompt loading

### DIFF
--- a/internal/attractor/engine/run_with_config.go
+++ b/internal/attractor/engine/run_with_config.go
@@ -22,7 +22,7 @@ func RunWithConfig(ctx context.Context, dotSource []byte, cfg *RunConfigFile, ov
 	applyConfigDefaults(cfg)
 
 	// Prepare graph (parse + transforms + validate).
-	g, _, err := Prepare(dotSource)
+	g, _, err := PrepareWithOptions(dotSource, PrepareOptions{RepoPath: cfg.Repo.Path})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/attractor/engine/transforms.go
+++ b/internal/attractor/engine/transforms.go
@@ -1,6 +1,13 @@
 package engine
 
-import "github.com/strongdm/kilroy/internal/attractor/model"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/strongdm/kilroy/internal/attractor/model"
+)
 
 // Transform can mutate the parsed graph between parse and validate (attractor-spec DoD).
 type Transform interface {
@@ -36,6 +43,49 @@ type goalExpansionTransform struct{}
 func (t goalExpansionTransform) ID() string { return "expand_goal" }
 func (t goalExpansionTransform) Apply(g *model.Graph) error {
 	expandGoal(g)
+	return nil
+}
+
+// expandPromptFiles resolves prompt_file attributes to inline prompt content.
+// For each node with a prompt_file attribute, the file is read relative to repoPath
+// and its contents replace the node's prompt. This runs before $goal expansion so
+// variables like $goal and $base_sha are still expanded in the loaded content.
+//
+// Rules:
+//   - prompt_file is resolved relative to repoPath (the repository root).
+//   - If both prompt and prompt_file are set, it is an error (ambiguous).
+//   - If the referenced file does not exist or is unreadable, it is an error.
+//   - After expansion, prompt_file is removed from the node attributes.
+func expandPromptFiles(g *model.Graph, repoPath string) error {
+	if repoPath == "" {
+		return nil
+	}
+	for _, n := range g.Nodes {
+		if n == nil {
+			continue
+		}
+		pf := strings.TrimSpace(n.Attrs["prompt_file"])
+		if pf == "" {
+			continue
+		}
+
+		// Conflict check: prompt_file and prompt are mutually exclusive.
+		if strings.TrimSpace(n.Attrs["prompt"]) != "" || strings.TrimSpace(n.Attrs["llm_prompt"]) != "" {
+			return fmt.Errorf("node %q: prompt_file and prompt are mutually exclusive", n.ID)
+		}
+
+		// Resolve path relative to repo root.
+		resolved := pf
+		if !filepath.IsAbs(pf) {
+			resolved = filepath.Join(repoPath, pf)
+		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return fmt.Errorf("node %q: prompt_file %q: %w", n.ID, pf, err)
+		}
+		n.Attrs["prompt"] = string(data)
+		delete(n.Attrs, "prompt_file")
+	}
 	return nil
 }
 

--- a/internal/attractor/engine/transforms_test.go
+++ b/internal/attractor/engine/transforms_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -71,6 +73,113 @@ digraph G {
 	}
 	if got := g.Attrs["x"]; got != "12" {
 		t.Fatalf("transform order: got %q want %q", got, "12")
+	}
+}
+
+func TestExpandPromptFiles_LoadsFileContent(t *testing.T) {
+	dir := t.TempDir()
+	promptContent := "Build all models from spec section 5.\n$goal\n"
+	if err := os.WriteFile(filepath.Join(dir, "prompts", "impl.md"), nil, 0o755); err != nil {
+		// Create dir first.
+	}
+	_ = os.MkdirAll(filepath.Join(dir, "prompts"), 0o755)
+	if err := os.WriteFile(filepath.Join(dir, "prompts", "impl.md"), []byte(promptContent), 0o644); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+
+	g := model.NewGraph("test")
+	n := model.NewNode("build")
+	n.Attrs["prompt_file"] = "prompts/impl.md"
+	_ = g.AddNode(n)
+
+	if err := expandPromptFiles(g, dir); err != nil {
+		t.Fatalf("expandPromptFiles: %v", err)
+	}
+
+	got := g.Nodes["build"].Attrs["prompt"]
+	if got != promptContent {
+		t.Fatalf("prompt = %q, want %q", got, promptContent)
+	}
+	if _, ok := g.Nodes["build"].Attrs["prompt_file"]; ok {
+		t.Fatal("prompt_file attribute should be removed after expansion")
+	}
+}
+
+func TestExpandPromptFiles_ErrorOnConflict(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "p.md"), []byte("content"), 0o644)
+
+	g := model.NewGraph("test")
+	n := model.NewNode("build")
+	n.Attrs["prompt_file"] = "p.md"
+	n.Attrs["prompt"] = "inline prompt"
+	_ = g.AddNode(n)
+
+	err := expandPromptFiles(g, dir)
+	if err == nil {
+		t.Fatal("expected error for conflicting prompt and prompt_file")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExpandPromptFiles_ErrorOnMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	g := model.NewGraph("test")
+	n := model.NewNode("build")
+	n.Attrs["prompt_file"] = "nonexistent.md"
+	_ = g.AddNode(n)
+
+	err := expandPromptFiles(g, dir)
+	if err == nil {
+		t.Fatal("expected error for missing prompt_file")
+	}
+	if !strings.Contains(err.Error(), "nonexistent.md") {
+		t.Fatalf("error should mention file path: %v", err)
+	}
+}
+
+func TestExpandPromptFiles_NoOpWithoutRepoPath(t *testing.T) {
+	g := model.NewGraph("test")
+	n := model.NewNode("build")
+	n.Attrs["prompt_file"] = "prompts/impl.md"
+	_ = g.AddNode(n)
+
+	// Should not error even though file doesn't exist — no repoPath means skip.
+	if err := expandPromptFiles(g, ""); err != nil {
+		t.Fatalf("expandPromptFiles with empty repoPath: %v", err)
+	}
+	// prompt_file should still be present (not resolved).
+	if _, ok := g.Nodes["build"].Attrs["prompt_file"]; !ok {
+		t.Fatal("prompt_file should remain when repoPath is empty")
+	}
+}
+
+func TestExpandPromptFiles_GoalExpansionStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "p.md"), []byte("Build: $goal"), 0o644)
+
+	dotSrc := []byte(`
+digraph G {
+  goal="Build the app"
+  start [shape=Mdiamond]
+  build [shape=box, prompt_file="p.md", llm_provider=openai, llm_model=gpt-5.2]
+  exit [shape=Msquare]
+  start -> build -> exit
+}
+`)
+	g, _, err := PrepareWithOptions(dotSrc, PrepareOptions{RepoPath: dir})
+	if err != nil {
+		t.Fatalf("PrepareWithOptions: %v", err)
+	}
+	got := g.Nodes["build"].Prompt()
+	if !strings.Contains(got, "Build the app") {
+		t.Fatalf("$goal not expanded in prompt_file content: %q", got)
+	}
+	if strings.Contains(got, "$goal") {
+		t.Fatalf("$goal placeholder still present: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Pipeline DOT files currently embed massive prompt strings inline, duplicating content from spec/plan markdown files. When the spec changes, every node prompt must be manually updated — and the DOT file becomes unreadable.

`prompt_file` lets nodes reference external markdown files instead:

```dot
build [shape=box, prompt_file=".ai/prompts/impl_models.md", llm_provider=openai, llm_model=gpt-5.2]
```

The engine resolves the path relative to the repo root during `Prepare()`, reads the file content, and sets it as the node's `prompt` attribute. All existing variable expansion (`$goal`, `$base_sha`) still works on loaded content.

### Before
```dot
build [
    shape=box,
    prompt="Goal: $goal\n\nRead .ai/spec.md thoroughly. All source code is in sections 5.9...5.13.\n\nImplement ALL model, service, viewmodel, and utility files:\n\n## Models (spec section 5.9)\n\n1. Ghostwriter/Models/MarkdownDocument.swift...\n\n2. Ghostwriter/Models/DocumentMetadata.swift...\n\n[...200 more lines embedded in DOT...]"
]
```

### After
```dot
build [shape=box, prompt_file=".ai/prompts/impl_models.md"]
```

## Design

- `prompt_file` resolves relative to `RepoPath` (the repo root)
- `prompt_file` and `prompt` are mutually exclusive — error if both set
- Missing files produce a clear error at prepare time with node ID and path
- Runs before `$goal` expansion so variables still work in loaded content
- `prompt_file` attribute is removed after expansion (downstream sees normal `prompt`)
- No-op when `RepoPath` is not set — fully backward compatible
- Validation lint catches `prompt_file` + `prompt` conflicts

## Changes

- `engine/transforms.go` — `expandPromptFiles()` function (52 lines)
- `engine/engine.go` — Added `RepoPath` to `PrepareOptions`, call expansion in `PrepareWithOptions`
- `engine/run_with_config.go` — Pass `RepoPath` through to `PrepareWithOptions`
- `validate/validate.go` — `lintPromptFileConflict` validator
- `engine/transforms_test.go` — 5 test cases covering happy path, conflict, missing file, no-op, and goal expansion

## Test plan

- [x] `TestExpandPromptFiles_LoadsFileContent` — reads file, sets prompt, removes prompt_file attr
- [x] `TestExpandPromptFiles_ErrorOnConflict` — errors when both prompt and prompt_file set
- [x] `TestExpandPromptFiles_ErrorOnMissingFile` — errors with clear message for missing files
- [x] `TestExpandPromptFiles_NoOpWithoutRepoPath` — skips gracefully when no repo path
- [x] `TestExpandPromptFiles_GoalExpansionStillWorks` — full pipeline: prompt_file → $goal expansion → validate
- [x] All existing transform, prepare, validate, and DOT parser tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)