### PR TITLE
fix(ci): gofmt all unformatted files (engine.go, worktree_hint_test.go, cli_only_models_test.go, codergen_router_cxdb_test.go)

### DIFF
--- a/internal/attractor/engine/cli_only_models_test.go
+++ b/internal/attractor/engine/cli_only_models_test.go
@@ -8,9 +8,9 @@ func TestIsCLIOnlyModel(t *testing.T) {
 		want  bool
 	}{
 		{"gpt-5.4-spark", false},
-		{"GPT-5.4-SPARK", false},       // case-insensitive
+		{"GPT-5.4-SPARK", false},        // case-insensitive
 		{"openai/gpt-5.4-spark", false}, // with provider prefix
-		{"gpt-5.4", false},             // regular codex
+		{"gpt-5.4", false},              // regular codex
 		{"gpt-5.4", false},
 		{"claude-opus-4-6", false},
 		{"", false},

--- a/internal/attractor/engine/codergen_router_cxdb_test.go
+++ b/internal/attractor/engine/codergen_router_cxdb_test.go
@@ -33,10 +33,10 @@ func TestEmitCXDBToolTurns_EmitsAssistantToolCallAndToolResult(t *testing.T) {
 		Kind:      agent.EventToolCallEnd,
 		Timestamp: time.Now(),
 		Data: map[string]any{
-			"tool_name":  "Read",
-			"call_id":    "toolu_123",
+			"tool_name":   "Read",
+			"call_id":     "toolu_123",
 			"full_output": "hello world",
-			"is_error":   false,
+			"is_error":    false,
 		},
 	})
 

--- a/internal/attractor/engine/engine.go
+++ b/internal/attractor/engine/engine.go
@@ -810,15 +810,15 @@ func (e *Engine) runLoop(ctx context.Context, current string, completed []string
 		}
 		next := nextHop.Edge
 		e.appendProgress(map[string]any{
-			"event":               "edge_selected",
-			"from_node":           node.ID,
-			"to_node":             next.To,
-			"label":               next.Label(),
-			"condition":           next.Condition(),
-			"hop_source":          string(nextHop.Source),
-			"selection_method":    nextHop.SelectionMeta.Method,
+			"event":                "edge_selected",
+			"from_node":            node.ID,
+			"to_node":              next.To,
+			"label":                next.Label(),
+			"condition":            next.Condition(),
+			"hop_source":           string(nextHop.Source),
+			"selection_method":     nextHop.SelectionMeta.Method,
 			"candidates_evaluated": nextHop.SelectionMeta.CandidatesEvaluated,
-			"conditions_matched":  nextHop.SelectionMeta.ConditionsMatched,
+			"conditions_matched":   nextHop.SelectionMeta.ConditionsMatched,
 		})
 
 		// loop_restart (attractor-spec §3.2 Step 7): terminate current run, re-launch
@@ -2067,7 +2067,7 @@ func hasMatchingOutgoingCondition(g *model.Graph, nodeID string, out runtime.Out
 
 // edgeSelectionMeta captures how edge selection resolved for decision logging.
 type edgeSelectionMeta struct {
-	Method             string // condition_match, preferred_label, suggested_next_ids, weight, only_edge, fallback
+	Method              string // condition_match, preferred_label, suggested_next_ids, weight, only_edge, fallback
 	CandidatesEvaluated int
 	ConditionsMatched   int
 }

--- a/internal/attractor/engine/worktree_hint_test.go
+++ b/internal/attractor/engine/worktree_hint_test.go
@@ -18,10 +18,10 @@ func TestExtractLeadingPath(t *testing.T) {
 		{"scripts/check.sh --flag", "scripts/check.sh"},
 		{"bash -c 'scripts/check.sh'", "scripts/check.sh"},
 		{"sh -c \"./run.sh arg1 arg2\"", "./run.sh"},
-		{"echo hello", ""},          // bare command, no path
-		{"ls", ""},                   // bare command
-		{"node app.js", ""},          // first token is bare command
-		{"", ""},                     // empty
+		{"echo hello", ""},  // bare command, no path
+		{"ls", ""},          // bare command
+		{"node app.js", ""}, // first token is bare command
+		{"", ""},            // empty
 		{"  ./test.sh  ", "./test.sh"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

4 files needed gofmt after recent batch merges. All pure whitespace — no logic changes.

| File | Source |
|------|--------|
| `cli_only_models_test.go` | whitespace drift from db00d48 batch merge |
| `codergen_router_cxdb_test.go` | new file from CXDB tests, not formatted |
| `engine.go` | struct literal alignment drift from PR #76 (decision logging) |
| `worktree_hint_test.go` | comment alignment drift from PR #78 (error UX) |

## Verification

\`\`\`
gofmt -l .   → clean
go vet ./... → clean
go build ./... → clean
\`\`\`

🤖 Servitor heartbeat fix — unblocks main CI